### PR TITLE
Add Dockerfile and .dockerignore for containerization support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+.venv/
+venv/
+ENV/
+env/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Git
+.git/
+.gitignore
+
+# Documentation
+*.md
+!README.md
+
+# MLflow
+mlruns/
+mlflow.db
+
+# Other
+.DS_Store
+*.log
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY src/ ./src/
+
+# Create models directory (will be mounted as volume)
+RUN mkdir -p /app/src/models
+
+# Expose the API port
+EXPOSE 5001
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app/src
+
+# Run the application
+CMD ["python", "src/web_api.py"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ waitress==3.0.2
 flask-cors==6.0.2
 Flask-Swagger-UI==5.21.0
 asset-model-data-storage==1.0.2
---index-url https://download.pytorch.org/whl/cu130
+#--index-url https://download.pytorch.org/whl/cu130 # uncomment this line if you are using a GPU
 torch==2.9.1
 torchvision==0.24.1
 mlflow==3.8.0


### PR DESCRIPTION
- Introduced a Dockerfile to set up a Python 3.12-slim environment, install dependencies, and configure the application for deployment.
- Added a .dockerignore file to exclude unnecessary files and directories from the Docker build context, improving build efficiency and security.
- Updated requirements.txt to comment out the GPU-specific index URL for torch, clarifying usage for different environments.